### PR TITLE
feat: Use new FRONTEND Local API.

### DIFF
--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -16,7 +16,7 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 
 	get requiredPorts() {
 		return {
-			NODEJS: 1,
+			HTTP: 1,
 		};
 	}
 
@@ -84,7 +84,6 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 	}
 
 	async finalizeNewSite(): Promise<void> {
-		serviceContainer.cradle.localLogger.log('info', 'finalizeNewSite');
 		const { wpCli, siteDatabase } = serviceContainer.cradle;
 
 		// eslint-disable-next-line default-case
@@ -126,12 +125,9 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 	}
 
 	get devEnvVars(): GenericObject {
-		const LOCAL_WP_HOST = this._site.host;
-
 		return {
-			LOCAL_WP_HOST,
 			PORT: this.port!.toString(),
-			WORDPRESS_API_URL: `http://${LOCAL_WP_HOST}/graphql`,
+			WORDPRESS_API_URL: `${this._site.backendUrl}/graphql`,
 		};
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ export default function (): void {
 			services.nodejs = {
 				version: '1.0.0',
 				type: Local.SiteServiceType.LIGHTNING,
-				role: Local.SiteServiceRole.OTHER,
+				role: Local.SiteServiceRole.FRONTEND,
 			};
 		}
 

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -10,8 +10,8 @@ const nodeJSSiteOverviewRowHook = (hooks) => {
 	const SiteOverviewRowHOC = withStoreProvider(SiteOverviewRow);
 	if (global.localhostRouting) {
 		hooks.addContent('SiteInfoOverview_TableList', (site: Site) => {
-			const hasNodeJSHeadlessSite = site?.services?.nodejs?.ports?.NODEJS[0];
-			const nodeJSHeadlessLocalUrl = `localhost:${site?.services?.nodejs?.ports?.NODEJS[0]}`;
+			const hasNodeJSHeadlessSite = site?.services?.nodejs?.ports?.HTTP[0];
+			const nodeJSHeadlessLocalUrl = `localhost:${site?.services?.nodejs?.ports?.HTTP[0]}`;
 
 			return (hasNodeJSHeadlessSite && <SiteOverviewRowHOC key={nodeJSHeadlessLocalUrl} localUrl={nodeJSHeadlessLocalUrl} />);
 		});


### PR DESCRIPTION
This work is an implementation of the changes found in: https://github.com/getflywheel/flywheel-local/pull/1009

By specifying that this service is a frontend service Local knows to use it for routing the site domain. 

Additionally to make this API more generic we need to specify the protocol used for this service in the `requiredPorts` getter, which is HTTP. 