### PR TITLE
fix: escape $LOCAL_ELECTRON_PATH in case of white space

### DIFF
--- a/electron-node/node
+++ b/electron-node/node
@@ -17,7 +17,7 @@ trap _term TERM
 trap _exit EXIT
 trap _int INT
 
-ELECTRON_RUN_AS_NODE=1 $LOCAL_ELECTRON_PATH "$@" &
+ELECTRON_RUN_AS_NODE=1 "$LOCAL_ELECTRON_PATH" "$@" &
 
 child=$!
 wait "$child"


### PR DESCRIPTION
### Summary

`/opt/Local Beta` on LInux (and the equivalent of osx) was breaking due to the white space when assigned to `$LOCAL_ELECTRON_PATH`

The fix: Quote to avoid Local Beta trying to access a Local stable install (which either doesn't exist or will cause execution permission errors if Local Beta tries to access it)