### PR TITLE
feat: Enable post previews when creating a new headless site. 

### DIFF
--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -156,6 +156,7 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 			await wpCli.run(this._site, [
 				'option',
 				'patch',
+				'insert',
 				'wpe_headless',
 				'frontend_uri',
 				this._site.frontendUrl,

--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -140,7 +140,26 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 				'wpe_headless',
 				'--format=json',
 			]);
-			const { secret_key: secretKey } = JSON.parse(headlessSettings);
+
+			const parsedHeadlessSettings: {
+				frontend_uri: string, // eslint-disable-line camelcase
+				secret_key: string, // eslint-disable-line camelcase
+				menu_locations: string, // eslint-disable-line camelcase
+				disable_theme: string, // eslint-disable-line camelcase
+				enable_rewrites: string, // eslint-disable-line camelcase
+				enable_redirects: string, // eslint-disable-line camelcase
+			} = JSON.parse(headlessSettings);
+			const { secret_key: secretKey } = parsedHeadlessSettings;
+
+			// Set the frontend_uri setting to the frontend service URL (this service).
+			// This is required for post previewing to work in WordPress.
+			await wpCli.run(this._site, [
+				'option',
+				'patch',
+				'wpe_headless',
+				'frontend_uri',
+				this._site.frontendUrl,
+			]);
 
 			// Write the required settings for the headless framework to `.env.local`.
 			const environmentFile = `WORDPRESS_URL=${this._site.backendUrl}

--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -121,7 +121,7 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 			await wpCli.run(this._site, [
 				'plugin',
 				'install',
-				'https://github.com/wp-graphql/wp-graphql/archive/v1.1.5.zip',
+				'wp-graphql',
 				'--activate',
 			]);
 
@@ -162,7 +162,6 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 			]);
 
 			// Write the required settings for the headless framework to `.env.local`.
-			const environmentFile = `WORDPRESS_URL=${this._site.backendUrl}
 # Plugin secret found in WordPress Settings->Headless
 WP_HEADLESS_SECRET=${secretKey}
 `;

--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -163,6 +163,7 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 			]);
 
 			// Write the required settings for the headless framework to `.env.local`.
+			const environmentFile = `NEXT_PUBLIC_WORDPRESS_URL=${this._site.backendUrl}
 # Plugin secret found in WordPress Settings->Headless
 WP_HEADLESS_SECRET=${secretKey}
 `;


### PR DESCRIPTION
There's a few things happening here! 

1) Install the latest version of the wp-graphql plugin so we're not installing outdated software. 
2) Configure the frontend_uri option in the settings for the headless WP plugin. 
3) Switch to client-side fetching which is required for post previews to work. This unfortunately will break Live Links support until we update the backend to allow us to proxy these client-side requests. 