### PR TITLE
Change Node startup command & update to latest Atlas starter kit example

### DIFF
--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -79,7 +79,7 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 					'--example',
 					'https://github.com/wpengine/headless-framework/tree/canary',
 					'--example-path',
-					'examples/getting-started',
+					'examples/next/getting-started',
 					'--use-npm',
 					headlessDirectoryName,
 				], {
@@ -199,9 +199,9 @@ WP_HEADLESS_SECRET=${secretKey}
 		return [
 			{
 				name: 'nodejs',
-				binPath: path.resolve(this.appNodePath, 'node_modules', 'next', 'dist', 'bin', 'next'),
-				args: ['dev', '-p', this.port!.toString()],
-				cwd: this.appNodePath,
+				binPath: path.resolve(nodeModulesPath, 'npm', 'bin', 'npm-cli.js'),
+				args: ['run', 'dev'],
+				cwd: path.join(this._site.longPath, headlessDirectoryName),
 				env: {
 					...this.defaultEnv,
 					...this.devEnvVars,

--- a/src/renderer/SiteOverviewAddonSection.tsx
+++ b/src/renderer/SiteOverviewAddonSection.tsx
@@ -31,6 +31,9 @@ const SiteOverview = (props: Props) => {
 
 	return (
 		<TableList>
+			<TableListRow label="Start Command" selectable>
+				<p><pre>npm run dev</pre></p>
+			</TableListRow>
 			<TableListRow label="Status" selectable>
 				<div style={{ flex: 1, display: 'flex', alignContent: 'center' }}>
 					<p style={{ textTransform: 'capitalize' }}>{siteStatus}</p>


### PR DESCRIPTION
Node start command now `npm run dev` giving devs more control.

Mapped starter kit code to the new path based on the latest DevRel refactor.