### PR TITLE
fix: use the new headless framework repo name

### DIFF
--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -175,13 +175,13 @@ WP_HEADLESS_SECRET=${secretKey}
 			// Report the error to the user, the Local log, and Sentry.
 			errorHandler.handleError({
 				error: e,
-				message: 'error encounted during finalizeNewSite step',
+				message: 'error encountered during finalizeNewSite step',
 				dialogTitle: 'Uh-oh! Local ran into an error.',
 				dialogMessage: e.toString(),
 			});
 
 			// Halt provisioning and cleanup.
-			throw new Error('error encounted during finalizeNewSite step');
+			throw new Error('error encountered during finalizeNewSite step');
 		}
 
 		LocalMain.sendIPCEvent(IPC_EVENTS.TRACK_EVENT, ANALYTIC_EVENTS.SITE_PROVISIONED);

--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -77,7 +77,7 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 					path.resolve(nodeModulesPath, 'npm', 'bin', 'npx-cli.js'),
 					'create-next-app',
 					'--example',
-					'https://github.com/wpengine/headless-framework/tree/canary',
+					'https://github.com/wpengine/faustjs/tree/canary',
 					'--example-path',
 					'examples/next/getting-started',
 					'--use-npm',

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -6,6 +6,7 @@ const stylesheetPath = path.resolve(__dirname, '../style.css');
 
 const title = `Front-end Node.js`;
 export const atlasDocsUrl = `https://developers.wpengine.com`;
+export const faustJsDocsUrl = `https://github.com/wpengine/faustjs`;
 
 const nodeJSSiteOverviewHook = (site: Site, siteStatus: string) => {
 	const hasNodeJSHeadlessSite = site?.services?.nodejs?.role;

--- a/src/renderer/HeadlessEnvironmentSelect.tsx
+++ b/src/renderer/HeadlessEnvironmentSelect.tsx
@@ -21,7 +21,7 @@ export const HeadlessEnvironmentSelect = () => {
 					<div className="AtlasTextLink">
 						<Text>
 							(Site will be built with a Node.js front-end powered <br/>
-							by <a href={atlasDocsUrl} style={{ fontWeight: 'bold' }}>WP Engine's Headless WordPress framework</a>)
+							by <a href={atlasDocsUrl} style={{ fontWeight: 'bold' }}>WP Engine's Headless WordPress framework, Faust.js</a>)
 						</Text>
 					</div>
 				</div>

--- a/src/renderer/HeadlessEnvironmentSelect.tsx
+++ b/src/renderer/HeadlessEnvironmentSelect.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Checkbox, Text } from '@getflywheel/local-components';
-import { atlasDocsUrl } from '../renderer';
+import { faustJsDocsUrl } from '../renderer';
 
 
 export const HeadlessEnvironmentSelect = () => {
@@ -21,7 +21,7 @@ export const HeadlessEnvironmentSelect = () => {
 					<div className="AtlasTextLink">
 						<Text>
 							(Site will be built with a Node.js front-end powered <br/>
-							by <a href={atlasDocsUrl} style={{ fontWeight: 'bold' }}>WP Engine's Headless WordPress framework, Faust.js</a>)
+							by <a href={faustJsDocsUrl} style={{ fontWeight: 'bold' }}>WP Engine's Headless WordPress framework, Faust.js</a>)
 						</Text>
 					</div>
 				</div>


### PR DESCRIPTION
The [Headless Framework](https://github.com/wpengine/faustjs) has been renamed to Faust.js.

This PR reflects those changes when a user selects an accompanying Node.js front end.