### PR TITLE
Internet Connectivity | Add messaging to create new Atlas site workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@getflywheel/local-addon-headless",
   "productName": "Atlas: Headless WP",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "Local Team",
   "keywords": [
     "local-addon"

--- a/package.json
+++ b/package.json
@@ -116,6 +116,6 @@
     "src/renderer/_browserWindows/local-logo-background.png"
   ],
   "engines": {
-    "local-by-flywheel": "^6.1.2"
+    "local-by-flywheel": "^6.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@getflywheel/eslint-config-local": "1.0.4",
-    "@getflywheel/local": "^5.10.0",
+    "@getflywheel/local": "^6.1.2",
     "@types/classnames": "^2.2.9",
     "@types/dateformat": "^3.0.1",
     "@types/enzyme": "^3.10.8",
@@ -79,6 +79,8 @@
     "graphql": "^15.5.0",
     "lodash": "^4.17.20",
     "md5": "^2.3.0",
+	"mobx": "^5.14.0",
+    "mobx-react": "^6.1.4",
     "npm": "^7.6.1",
     "prop-types": "^15.6.2",
     "react": "^16.10.2",
@@ -114,6 +116,6 @@
     "src/renderer/_browserWindows/local-logo-background.png"
   ],
   "engines": {
-    "local-by-flywheel": "^5.10.0"
+    "local-by-flywheel": "^6.1.2"
   }
 }

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -42,7 +42,9 @@ export default function (context) {
 	));
 
 	// Create the additional selection option to be displayed during site creation
-	hooks.addContent('NewSiteEnvironment_EnvironmentDetails', () => <HeadlessEnvironmentSelect />);
+	hooks.addContent('NewSiteEnvironment_EnvironmentDetails', function () {
+		return <HeadlessEnvironmentSelect rerenderParent={this.forceUpdate.bind(this)} hooks={hooks} />;
+	});
 
 	hooks.addFilter('SiteInfoOverview_Addon_Section', (content, site: Site, siteStatus: string) => {
 

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -42,9 +42,7 @@ export default function (context) {
 	));
 
 	// Create the additional selection option to be displayed during site creation
-	hooks.addContent('NewSiteEnvironment_EnvironmentDetails', function () {
-		return <HeadlessEnvironmentSelect rerenderParent={this.forceUpdate.bind(this)} hooks={hooks} />;
-	});
+	hooks.addContent('NewSiteEnvironment_EnvironmentDetails', ({ disableButton }) => <HeadlessEnvironmentSelect disableButton={disableButton} />);
 
 	hooks.addFilter('SiteInfoOverview_Addon_Section', (content, site: Site, siteStatus: string) => {
 

--- a/src/renderer/HeadlessEnvironmentSelect.tsx
+++ b/src/renderer/HeadlessEnvironmentSelect.tsx
@@ -4,7 +4,14 @@ import { faustJsDocsUrl } from '../renderer';
 import { useObserver } from 'mobx-react';
 import { $offline } from '@getflywheel/local/renderer';
 
-export const HeadlessEnvironmentSelect = (props) => useObserver(() => {
+type Props = {
+	hooks: {
+		addFilter(hook: string, ...args),
+	},
+	rerenderParent: () => void,
+}
+
+export const HeadlessEnvironmentSelect: React.FC<Props> = (props) => useObserver(() => {
 	const [checked, setChecked] = useState(false);
 
 	useEffect(() => {

--- a/src/renderer/HeadlessEnvironmentSelect.tsx
+++ b/src/renderer/HeadlessEnvironmentSelect.tsx
@@ -1,11 +1,25 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Checkbox, Text } from '@getflywheel/local-components';
 import { faustJsDocsUrl } from '../renderer';
+import { useObserver } from 'mobx-react';
+import { $offline } from '@getflywheel/local/renderer';
 
+export const HeadlessEnvironmentSelect = (props) => useObserver(() => {
+	const [checked, setChecked] = useState(false);
 
-export const HeadlessEnvironmentSelect = () => {
+	useEffect(() => {
+		const disable = $offline.offline && checked;
 
-	const [checked, setChecked] = useState();
+		props.hooks.addFilter('NewSiteEnvironment_ContinueButton', function () {
+			if (disable) {
+				return this.renderOfflineButtonWithTooltip();
+			}
+
+			return this.renderContinueButton();
+		});
+
+		props.rerenderParent();
+	}, [checked]);
 
 	return (
 		<div>
@@ -28,4 +42,4 @@ export const HeadlessEnvironmentSelect = () => {
 			</div>
 		</div>
 	);
-};
+});

--- a/src/renderer/HeadlessEnvironmentSelect.tsx
+++ b/src/renderer/HeadlessEnvironmentSelect.tsx
@@ -14,8 +14,10 @@ type Props = {
 export const HeadlessEnvironmentSelect: React.FC<Props> = (props) => useObserver(() => {
 	const [checked, setChecked] = useState(false);
 
+	const { offline } = $offline;
+
 	useEffect(() => {
-		const disable = $offline.offline && checked;
+		const disable = offline && checked;
 
 		props.hooks.addFilter('NewSiteEnvironment_ContinueButton', function () {
 			if (disable) {
@@ -26,7 +28,7 @@ export const HeadlessEnvironmentSelect: React.FC<Props> = (props) => useObserver
 		});
 
 		props.rerenderParent();
-	}, [checked]);
+	}, [checked, offline]);
 
 	return (
 		<div>

--- a/src/renderer/HeadlessEnvironmentSelect.tsx
+++ b/src/renderer/HeadlessEnvironmentSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Checkbox, Text } from '@getflywheel/local-components';
 import { faustJsDocsUrl } from '../renderer';
 import { useObserver } from 'mobx-react';

--- a/src/renderer/HeadlessEnvironmentSelect.tsx
+++ b/src/renderer/HeadlessEnvironmentSelect.tsx
@@ -5,10 +5,7 @@ import { useObserver } from 'mobx-react';
 import { $offline } from '@getflywheel/local/renderer';
 
 type Props = {
-	hooks: {
-		addFilter(hook: string, ...args),
-	},
-	rerenderParent: () => void,
+	disableButton: (value: boolean) => void;
 }
 
 export const HeadlessEnvironmentSelect: React.FC<Props> = (props) => useObserver(() => {
@@ -16,19 +13,10 @@ export const HeadlessEnvironmentSelect: React.FC<Props> = (props) => useObserver
 
 	const { offline } = $offline;
 
-	useEffect(() => {
-		const disable = offline && checked;
-
-		props.hooks.addFilter('NewSiteEnvironment_ContinueButton', function () {
-			if (disable) {
-				return this.renderOfflineButtonWithTooltip();
-			}
-
-			return this.renderContinueButton();
-		});
-
-		props.rerenderParent();
-	}, [checked, offline]);
+	const onChange = (value: boolean) => {
+		setChecked(value);
+		props.disableButton(value && offline);
+	};
 
 	return (
 		<div>
@@ -39,7 +27,7 @@ export const HeadlessEnvironmentSelect: React.FC<Props> = (props) => useObserver
 						style={{ marginTop: 10 }}
 						checked={checked}
 						label="Enable Atlas Add-on on this site."
-						onChange={(checked) => setChecked(checked)}
+						onChange={(checked) => onChange(checked)}
 					/>
 					<div className="AtlasTextLink">
 						<Text>

--- a/style.css
+++ b/style.css
@@ -1,5 +1,12 @@
 .AtlasCheckboxSelect {
 	padding-top: 30px;
+}
+
+.Theme__Dark .AtlasCheckboxSelect {
+	border-top: 1px solid #5d5e5e;
+}
+
+.Theme__Light .AtlasCheckboxSelect {
 	border-top: 1px solid #e7e7e7;
 }
 

--- a/style.css
+++ b/style.css
@@ -18,3 +18,9 @@
 	font-weight: bold;
 	margin-top: 20px;
 }
+
+.SiteEnvironmentContinueButton {
+	position: absolute;
+    bottom: 30px;
+    right: 30px;
+}


### PR DESCRIPTION
This PR implements the `'NewSiteEnvironment_ContinueButton'` filter hook. It relies on scoped methods in the `NewSiteEnvironment.tsx` component to dynamically render the continue button. I also added `mobx` & `mobx-react` to make use of the `$offline` store.

I had to do a `forceUpdate` in the parent component, otherwise the page wouldn't react to the checkmark state.

There is a companion PR for this in `flywheel-local`.