### PR TITLE
feat: implement importSiteManifest hook

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,16 @@ export default function (): void {
 		return services;
 	});
 
+	LocalMain.HooksMain.addFilter('importSiteManifest', (manifest: LocalMain.IImportSiteSettings, site: Site) => {
+		const modifiedManifest = { ...manifest };
+
+		if (site.getSiteServiceByRole(Local.SiteServiceRole.FRONTEND)) {
+			modifiedManifest.customOptions.useAtlasFramework = 'on';
+		}
+
+		return modifiedManifest;
+	});
+
 	LocalMain.HooksMain.addFilter('exportSiteFileFilter', (allowFile, file, pathInArchive) => {
 		// exclude node modules from being exported on headless sites
 		if (pathInArchive.indexOf(`/${headlessDirectoryName}/node_modules`) === 0) {


### PR DESCRIPTION
Implement the `'importSiteManifest` hook from https://github.com/getflywheel/flywheel-local/pull/1266

## Technical

Checks for the nodejs aka the `Local.SiteServiceRole.FRONTEND` service and adds `useAtlasFramework: 'on'` to the `customOptions` object for the imported site settings.