### PR TITLE
feat: update env.local file with new backendUrl on import

### DIFF
--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -74,6 +74,17 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 					cwd: path.join(this._site.longPath, headlessDirectoryName),
 					env: this.defaultEnv,
 				});
+
+				const envFilePath = path.join(this.appNodePath, '.env.local');
+				if (fs.existsSync(envFilePath)) {
+					// we need to update the NEXT_PUBLIC_WORDPRESS_URL and set it to the new sites backendurl
+					const envFileContent = fs.readFileSync(envFilePath).toString();
+					const updatedEnvFileContent = envFileContent.replace(
+						/^NEXT_PUBLIC_WORDPRESS_URL=(.*)/,
+						`NEXT_PUBLIC_WORDPRESS_URL=${this._site.backendUrl}`,
+					);
+					fs.writeFileSync(envFilePath, updatedEnvFileContent);
+				}
 			} else {
 				await execFilePromise(this.bin!.electron, [
 					path.resolve(nodeModulesPath, 'npm', 'bin', 'npx-cli.js'),


### PR DESCRIPTION
When we import a site, we need to update the `NEXT_PUBLIC_WORDPRESS_URL` in `.env.local` to match the new sites `backendUrl` url assigned by Local. 

When the Atlas addon is installed, Local treats NodeJS as a lightning-service. This `env.file` update logic happens during the `preprovision` step during site provisioning (See `SiteProvisionerService.ts`: https://github.com/getflywheel/flywheel-local/blob/f7d1dc9f511ab88c11f7940298d1666bb27481d9/app/main/sites/SiteProvisionerService.ts#L231).

