### PR TITLE
feat: use importSiteChangeDomain hook to update the frontend_uri value

### DIFF
--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -74,6 +74,17 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 					cwd: path.join(this._site.longPath, headlessDirectoryName),
 					env: this.defaultEnv,
 				});
+
+				const envFilePath = path.join(this.appNodePath, '.env.local');
+				if (fs.existsSync(envFilePath)) {
+					// we need to update the NEXT_PUBLIC_WORDPRESS_URL and set it to the new sites backendurl
+					const envFileContent = fs.readFileSync(envFilePath).toString();
+					const updatedEnvFileContent = envFileContent.replace(
+						/^NEXT_PUBLIC_WORDPRESS_URL=(.*)/,
+						`NEXT_PUBLIC_WORDPRESS_URL=${this._site.backendUrl}`,
+					);
+					fs.writeFileSync(envFilePath, updatedEnvFileContent);
+				}
 			} else {
 				await execFilePromise(this.bin!.electron, [
 					path.resolve(nodeModulesPath, 'npm', 'bin', 'npx-cli.js'),


### PR DESCRIPTION
Summary:

We need make 2 `wpCli` calls in order to update the `frontend_uri` value in `faustwp_settings`. 1 to get the original value, 2 to make the update.

The original intent was to do a search and replace for all instances of the old `frontend_uri` value, but I noticed that changing the `frontend_uri` via the plugin doesn't do a full search and replace for old guid links, and so I don't think Local needs to either. 

I also prefer how isolated the change is. We can update the option and let the framework take care of the site, rather than making too many updates to a user's db. Let me know though if you disagree with this thinking.

To test:

- You'll need a build from https://github.com/getflywheel/flywheel-local/pull/1278 otherwise the hook won't exist for the addon.
- Symlink the atlas addon into your addons dir for Local `ln -s ~/Development/local-addon-atlas ~/Library/Application\ Support/Local/addons`
- `yarn && yarn build`
- Start local and import a headless site/ create a headless site from blueprint