### PR TITLE
fix: remove fragment & add missing keys to AtlasBlueprintCard & Atlas…

### DIFF
--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -54,7 +54,7 @@ export default function (context) {
 	);
 
 	hooks.addContent('Blueprints_BlueprintsList:after', () => (
-		<AtlasBlueprints />
+		<AtlasBlueprints key="atlas-blueprints" />
 	));
 
 	hooks.addFilter(

--- a/src/renderer/AtlasBlueprintCard.tsx
+++ b/src/renderer/AtlasBlueprintCard.tsx
@@ -24,37 +24,35 @@ const AtlasBlueprintCard: React.FC<AtlasBlueprintCardProps> = ({
 	previewHref,
 	repoHref,
 }) => (
-	<>
-		<Card
-			className="AtlasBlueprintCard"
-			headerIconContainerClassName="AtlasBlueprintCard_HeaderIconContainer"
-			headerIconPath={thumbnailSrc}
-			contentClassName="AtlasBlueprintCard_Content"
-			contentDescriptionClassName="AtlasBlueprintCard_Description"
-			contentTitle={title}
-			contentSub={byline}
-			contentDescription={excerpt}
-			content={
-				<Container className="AtlasBlueprintCard_Links">
-					<TextButton tag="a" tagProps={{ href: previewHref }}>
+	<Card
+		className="AtlasBlueprintCard"
+		headerIconContainerClassName="AtlasBlueprintCard_HeaderIconContainer"
+		headerIconPath={thumbnailSrc}
+		contentClassName="AtlasBlueprintCard_Content"
+		contentDescriptionClassName="AtlasBlueprintCard_Description"
+		contentTitle={title}
+		contentSub={byline}
+		contentDescription={excerpt}
+		content={
+			<Container className="AtlasBlueprintCard_Links">
+				<TextButton tag="a" tagProps={{ href: previewHref }}>
 						Preview Site
-					</TextButton>
-					<TextButton tag="a" tagProps={{ href: repoHref }}>
+				</TextButton>
+				<TextButton tag="a" tagProps={{ href: repoHref }}>
 						Open the code on GitHub
-					</TextButton>
-					<Divider />
-					<TextButton
-						tag="a"
-						onClick={() => {
-							alert('Atlas Blueprint Details');
-						}}
-					>
+				</TextButton>
+				<Divider />
+				<TextButton
+					tag="a"
+					onClick={() => {
+						alert('Atlas Blueprint Details');
+					}}
+				>
 						Show more details
-					</TextButton>
-				</Container>
-			}
-		/>
-	</>
+				</TextButton>
+			</Container>
+		}
+	/>
 );
 
 export default AtlasBlueprintCard;

--- a/src/renderer/AtlasBlueprints.tsx
+++ b/src/renderer/AtlasBlueprints.tsx
@@ -36,6 +36,7 @@ const AtlasBlueprints: React.FC = () => (
 		<Container className="AtlasBlueprintList">
 			{atlasBlueprints.map((bp) => (
 				<AtlasBlueprintCard
+					key={bp.title}
 					thumbnailSrc={bp.thumbnail}
 					title={bp.title}
 					byline={bp.byline}


### PR DESCRIPTION
When our content hooks are rendered in the main app, they are elements enclosed with brackets (much like returning elements in a component via a `.map`). Because of this, we need to add a hook when returning a component via the `addContent` hook. 

Additionally, this PR adds keys to the `AtlasBlueprintCard` component in `AtlasBlueprints.tsx` & removes an unnecessary fragment from `AtlasBlueprintCard.tsx`.