### PR TITLE
fix: disable swc compiler on Windows

### DIFF
--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import os from 'os';
 import fs from 'fs-extra';
 import { IPC_EVENTS, ANALYTIC_EVENTS, headlessDirectoryName } from './constants';
 import * as LocalMain from '@getflywheel/local/main';
@@ -99,6 +100,12 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 					cwd: this._site.longPath,
 					env: this.defaultEnv,
 				});
+			}
+
+			if (os.platform() === 'win32') {
+				const babelrc = `{"presets":["next/babel"]}`;
+
+				await fs.writeFile(path.join(this.appNodePath, '.babelrc'), babelrc);
 			}
 
 			/**


### PR DESCRIPTION
Windows users couldn't create new Atlas sites, the create site process would seem successful in the UI, but it would fail silently and a 502 error would appear in the browser if a user tried to visit the site.

Nextjs (the underlying framework used by faust.js (the framework created by the Atlas team)) recently switched to using the SWC rust compiler instead of babel. Because of this, an arch-specific binary of the compiler is shipped when node_modules is installed. For some reason, still a mystery to me, the 32 bit compiler fails. However, the 64 bit compiler works. 

Rather than convert Local into a 64bit app (which solved the issue for 64bit Windows users), we decided to temporarily disable the swc by adding a `.babelrc` config with the `{"presets":["next/babel"]}` -- basically telling next.js to ignore the swc compiler until we can figure out what our next move is.

This PR checks for the platform, and if it's windows adds a `.babelrc` file to the `app-node` dir.