### PR TITLE
feat: add hook for site shell

### DIFF
--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -147,19 +147,21 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 				'--activate',
 			]);
 
-			// Add the FaustWP plugin.
-			await wpCli.run(this._site, [
-				'plugin',
-				'install',
-				'faustwp',
-				'--activate',
-			]);
-
 			// Add the atlas-content-modeler plugin.
 			await wpCli.run(this._site, [
 				'plugin',
 				'install',
 				'atlas-content-modeler',
+				'--activate',
+			]);
+
+			LocalMain.sendIPCEvent('siteShellEntry:launch', this._site, 'atlas');
+
+			// Add the FaustWP plugin.
+			await wpCli.run(this._site, [
+				'plugin',
+				'install',
+				'faustwp',
 				'--activate',
 			]);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,20 @@ export default function (): void {
 		LocalMain.sendIPCEvent(IPC_EVENTS.TRACK_EVENT, ANALYTIC_EVENTS.OPEN_XTERM);
 	});
 
+	LocalMain.HooksMain.addFilter('modifyScriptContent', (site: Site, hookOrigin: string) => {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		const { atlasUrl, useAtlasFramework } = site.customOptions;
+
+		if (useAtlasFramework === 'on' && hookOrigin === 'atlas') {
+			const rawZipUrl = '/raw/main/acm-blueprint.zip';
+
+			return `wp acm blueprint import ${atlasUrl}${rawZipUrl}; exit;`;
+		}
+
+		return '';
+	});
+
 	LocalMain.HooksMain.addFilter('defaultSiteServices', (services, siteSettings) => {
 		if (siteSettings?.customOptions?.useAtlasFramework === 'on') {
 			services.nodejs = {


### PR DESCRIPTION
## Summary

This PR ensures that the ACM Blueprint import command is run for newly created Atlas Blueprint sites. There is also a [companion ticket](https://github.com/getflywheel/flywheel-local/pull/1349) in Local core.

## Technical

A filter hook is added that modifies the entry script for the site shell when it is opened. The hook utilizes a `hookOrigin` string which is set in a new `preLaunch` function in order to verify where the injection is coming from. If a user clicks to open the site shell or another repo/addon has a hook the one in Atlas will not trigger. After the command is complete the shell exits.

This needs further testing on Windows at the moment.

## Reference
- [LOC-3320](https://wpengine.atlassian.net/browse/LOC-3320)