### PR TITLE
fix: return the filtered site object from modifyAddSiteObjectBeforeCreation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,8 @@ export default function (): void {
 				// @ts-ignore
 				site.customOptions = { ...newSiteInfo.customOptions };
 			}
+
+			return site;
 		},
 	);
 


### PR DESCRIPTION
TL/DR: Always return the filtered value in a hook filter callback.

Both Atlas and Cloud Backups utilize the `modifyAddSiteObjectBeforeCreation` filter hook, but the callback implemented in `local-addon-atlas` wasn't returning the filtered `site` object. The way our filter hooks work is we loop through each registered filter and set the passed `value` (the filtered object) to the result of the current filter.

So, in my case, for some reason, maybe because of the order I had installed Atlas and Cloud Backups, the Atlas filter was registered and running before the backups one. Since it returned nothing, Cloud Backups was getting passed `undefined` instead of the `site` object it was expecting.

Should fix this error I was seeing when trying to create a site with both Cloud Backups and Atlas installed: 

```javascript
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
TypeError: Cannot set property 'cloudBackupMeta' of undefined
    at Function.<anonymous> (/Users/adam.perry/dev/local/local-addons/local-addon-backups/lib/main.js:498:30)
    at /Users/adam.perry/dev/local/flywheel-local/build/main/_helpers/HooksMain.js:56:57
    at Array.forEach (<anonymous>)
    at Function.applyFilters (/Users/adam.perry/dev/local/flywheel-local/build/main/_helpers/HooksMain.js:54:49)
    at AddSiteService.<anonymous> (/Users/adam.perry/dev/local/flywheel-local/build/main/sites/AddSiteService.js:159:40)
    at Generator.next (<anonymous>)
    at /Users/adam.perry/dev/local/flywheel-local/build/main/sites/AddSiteService.js:27:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/adam.perry/dev/local/flywheel-local/build/main/sites/AddSiteService.js:23:12)
    at AddSiteService.addSite (/Users/adam.perry/dev/local/flywheel-local/build/main/sites/AddSiteService.js:141:16)
```