### PR TITLE
Remove `basic` and `blog` blueprints

### DIFF
--- a/atlas-blueprints/blueprintsContent.js
+++ b/atlas-blueprints/blueprintsContent.js
@@ -2,20 +2,6 @@ import path from 'path';
 
 const atlasBlueprints = [
 	{
-		id: 'basic-blueprint-atlas-1',
-		thumbnail: path.resolve(
-			__dirname,
-			'../atlas-blueprints/basic-blueprint.png',
-		),
-		title: 'Basic Blueprint',
-		byline: 'Headless WordPress',
-		excerpt:
-			'A bare-bones headless site with enough scaffolding to get you started.',
-		previewHref:
-			'https://wpeng.in/atlas-blueprint-basic',
-		repoHref: 'https://github.com/wpengine/atlas-blueprint-basic',
-	},
-	{
 		id: 'portfolio-blueprint-atlas-1',
 		thumbnail: path.resolve(
 			__dirname,
@@ -28,20 +14,6 @@ const atlasBlueprints = [
 		previewHref:
 			'https://wpeng.in/atlas-blueprint-portfolio',
 		repoHref: 'https://github.com/wpengine/atlas-blueprint-portfolio',
-	},
-	{
-		id: 'blog-blueprint-atlas-1',
-		thumbnail: path.resolve(
-			__dirname,
-			'../atlas-blueprints/blog-blueprint.png',
-		),
-
-		title: 'Blog Blueprint',
-		byline: 'Headless WordPress',
-		excerpt: 'Spin up this Blueprint if you want a classic WordPress-style blog. Share your thoughts with individual blog posts and navigation pages.',
-		previewHref:
-			'https://wpeng.in/atlas-blueprint-blog',
-		repoHref: 'https://github.com/wpengine/atlas-blueprint-blog',
 	},
 ];
 


### PR DESCRIPTION
This PR removes the `basic` and `blog` Blueprints from the Atlas Addon as they have been deprecated.