### PR TITLE
Add `FAUST_NO_INTERACTION` dev env var

### DIFF
--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -251,6 +251,10 @@ FAUSTWP_SECRET_KEY=${secretKey}
 			PORT: this.port!.toString(),
 			WORDPRESS_URL: this._site.backendUrl,
 			WORDPRESS_API_URL: `${this._site.backendUrl}/graphql`,
+			/**
+			 *  Do not prompt users for Faust Telemetry when running `npm run dev`
+			 */
+			FAUST_TELEMETRY_PROMPT: 'false',
 		};
 	}
 

--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -254,7 +254,7 @@ FAUSTWP_SECRET_KEY=${secretKey}
 			/**
 			 *  Do not prompt users for Faust Telemetry when running `npm run dev`
 			 */
-			FAUST_TELEMETRY_PROMPT: 'false',
+			FAUST_NO_INTERACTION: 'true',
 		};
 	}
 


### PR DESCRIPTION
We've recently identified that with the new version of Faust and the telemetry prompt, it can stall when running in Local because we have no context whether or not the `npm run dev` command was ran by a human or programattically.

We've since introduced some conditional logic that looks for the `FAUST_NO_INTERACTION` flag, and when set, will not prompt the user.

This PR adds the following env var to the dev env vars in Local's Node env.