### PR TITLE
chore: prepare release of 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@getflywheel/local-addon-headless",
 	"productName": "Atlas: Headless WP",
-	"version": "1.4.2",
+	"version": "1.5.0",
 	"author": "Local Team",
 	"keywords": [
 		"local-addon"


### PR DESCRIPTION
Bumps version to prepare for release of 1.5.0.

1.5.0 will include updates for breaking changes that stop Faust/headless sites from starting:
- https://github.com/getflywheel/local-addon-atlas/pull/46 (removing templates, hence bump to 1.5)
- https://github.com/getflywheel/local-addon-atlas/pull/47

Updates to Electron/Local dependencies will be a separate release.