### PR TITLE
Update example project directory

### DIFF
--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -90,7 +90,7 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 			} else {
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
-				const atlasUrl = this._site?.customOptions?.atlasUrl ?? 'https://github.com/wpengine/faustjs/tree/main/examples/next/getting-started';
+				const atlasUrl = this._site?.customOptions?.atlasUrl ?? 'https://github.com/wpengine/faustjs/tree/main/examples/next/faustwp-getting-started';
 
 				await execFilePromise(this.bin!.electron, [
 					path.resolve(nodeModulesPath, 'npm', 'bin', 'npx-cli.js'),


### PR DESCRIPTION
This addon was using the outdated Faust example project. This PR updates the example project to use the new `faustwp-getting-started` example.