### PR TITLE
[LOC-5015] Update Faust starter URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@getflywheel/local-addon-headless",
 	"productName": "Atlas: Headless WP",
-	"version": "1.6.1",
+	"version": "1.6.2",
 	"author": "Local Team",
 	"keywords": [
 		"local-addon"

--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -90,7 +90,7 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 			} else {
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
-				const atlasUrl = this._site?.customOptions?.atlasUrl ?? 'https://github.com/wpengine/faustjs/tree/main/examples/next/getting-started';
+				const atlasUrl = this._site?.customOptions?.atlasUrl ?? 'https://github.com/wpengine/faustjs/tree/main/examples/next/faustwp-getting-started';
 
 				await execFilePromise(this.bin!.electron, [
 					path.resolve(nodeModulesPath, 'npm', 'bin', 'npx-cli.js'),

--- a/src/NodeJSService.ts
+++ b/src/NodeJSService.ts
@@ -110,15 +110,6 @@ export default class LightningServiceNodeJS extends LocalMain.LightningService {
 
 				await fs.writeFile(path.join(this.appNodePath, '.babelrc'), babelrc);
 			}
-
-			/**
-			 * @todo Next.js doesn't support an env var for the start port. This is a termpoary hack around it.
-			 *
-			 * @see https://github.com/vercel/next.js/issues/10338
-			 */
-			await LocalMain.replaceInFileAsync(path.join(this.appNodePath, 'package.json'), [
-				['"dev": "next dev",', '"dev": "next dev -p $PORT",'],
-			]);
 		} catch (e) {
 			// Report the error to the user, the Local log, and Sentry.
 			errorHandler.handleError({


### PR DESCRIPTION
- Updates Faust starter URL to use https://github.com/wpengine/faustjs/tree/main/examples/next/faustwp-getting-started.
- Removes logic to rewrite the `dev` startup script — Next.js now supports passing the port number, so that Faust startup commands work without modification.
- Bumps add-on version.

## To test
1. `npm i && npm pack` to generate the add-on file (or use the version provided in Slack).
2. Remove the existing Atlas add-on and install the add-on manually.
3. Try creating a new Atlas site using the “Custom” option, ticking “Enable Atlas add-on for this site”.

<img width="774" alt="Screen showing Enable Atlas add-on option" src="https://user-images.githubusercontent.com/647669/235717202-f1cd59d7-7f90-4a0f-b3a3-1870dbd75db3.png">

Sites created using the Atlas blueprints should also continue working.

Replaces https://github.com/getflywheel/local-addon-atlas/pull/54.