### PR TITLE
Fix WPGraphQL ACF plugin url

### DIFF
--- a/atlas-blueprints/blueprintsContent.js
+++ b/atlas-blueprints/blueprintsContent.js
@@ -16,7 +16,7 @@ const atlasBlueprints = [
 		repoHref: 'https://github.com/wpengine/faust-scaffold',
 		additionalPlugins: [
 			'advanced-custom-fields',
-			'https://github.com/wp-graphql/wpgraphql-acf/releases/latest/download/wp-graphql-acf.zip',
+			'https://github.com/wp-graphql/wpgraphql-acf/releases/latest/download/wpgraphql-acf.zip',
 			'https://wp-product-info.wpesvc.net/v1/plugins/wpe-atlas-headless-extension?download',
 			'atlas-search',
 		],
@@ -38,7 +38,7 @@ const atlasBlueprints = [
 		repoHref: 'https://github.com/wpengine/atlas-blueprint-portfolio',
 		additionalPlugins: [
 			'advanced-custom-fields',
-			'https://github.com/wp-graphql/wpgraphql-acf/releases/latest/download/wp-graphql-acf.zip',
+			'https://github.com/wp-graphql/wpgraphql-acf/releases/latest/download/wpgraphql-acf.zip',
 			'https://wp-product-info.wpesvc.net/v1/plugins/wpe-atlas-headless-extension?download',
 			'atlas-search',
 		],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@getflywheel/local-addon-headless",
 	"productName": "Atlas: Headless WP",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"author": "Local Team",
 	"keywords": [
 		"local-addon"


### PR DESCRIPTION
To prevent new site creation failure when attempting to add a site using the Atlas Scaffolding or Atlas Portfolio blueprints.

[Slack thread for context](https://wpengine.slack.com/archives/C019A24SQSD/p1697206404124159).

## Root cause

Local was using the correct link:

```
https://github.com/wp-graphql/wpgraphql-acf/releases/latest/download/wp-graphql-acf.zip
```

But the [latest release of that plugin](https://github.com/wp-graphql/wpgraphql-acf/releases/tag/v2.0.0-beta.5.0.0) changed the zip file name to:

```
https://github.com/wp-graphql/wpgraphql-acf/releases/latest/download/wpgraphql-acf.zip
```

Jason B. says that will be the new path from now on, so we have to change it here. `wp plugin install` does not follow redirects (a `wpeng.in` link would not work), which leaves us having to hard-code paths here for now until there's a remote API for this.

## Built version

[getflywheel-local-addon-headless-1.7.2.tgz](https://github.com/getflywheel/local-addon-atlas/files/12895192/getflywheel-local-addon-headless-1.7.2.tgz)

## Install error example

![screenshot_2023-10-13_at_8 57 34_am](https://github.com/getflywheel/local-addon-atlas/assets/647669/a13f0e30-9106-45f2-b0ee-a85ddd21b54c)