### PR TITLE
[LOC-6148] Fix console output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@getflywheel/local-addon-headless",
 	"productName": "Atlas: Headless WP",
-	"version": "1.7.4",
+	"version": "1.7.5",
 	"author": "Local Team",
 	"keywords": [
 		"local-addon"

--- a/src/helpers/terminalWindowManager.ts
+++ b/src/helpers/terminalWindowManager.ts
@@ -154,7 +154,7 @@ export const createNewTerminalWindow = (site: Site): BrowserWindow => {
 		deregisterBrowserWindowBySiteID(siteID);
 	});
 
-	terminalWindow.loadFile(path.resolve(__dirname, '../../src/renderer/_browserWindows/xterm.html'));
+	terminalWindow.loadFile(path.resolve(__dirname, '../src/renderer/_browserWindows/xterm.html'));
 
 	return terminalWindow;
 };


### PR DESCRIPTION
Fix path to `xterm.html` so that console output appears again.

## To test

1. In Local, stop all sites. Browse to add-ons → installed.
2. Click the options menu (…) to the right of Atlas: Headless WP, choose "Uninstall" and confirm the uninstall and restart (your existing Atlas sites will not be affected).
3. [Download version 1.7.5 of the add-on](https://cdn.localwp.com/addons/getflywheel-local-addon-headless-1.7.5.tgz) that I compiled from this PR.
4. In Local, browse to add-ons → installed, choose "install from disk", and select the file you downloaded in step 3.
5. Activate the add-on and restart Local.

Try starting or creating an Atlas site and checking console output. You should see something like the output below.

![CleanShot 2025-01-07 at 16 48 31@2x](https://github.com/user-attachments/assets/a3bce9d3-79de-4fe5-875e-44c861534cc8)

![CleanShot 2025-01-07 at 16 41 33@2x](https://github.com/user-attachments/assets/c00bf3fe-07f1-48cb-8f3f-d22a3444bded)

Streaming output when opening the front end:

![CleanShot 2025-01-07 at 16 52 43@2x](https://github.com/user-attachments/assets/218163ff-db63-4798-ad09-fc7100051b33)

## Ref
- https://wpengine.atlassian.net/browse/LOC-6148
- https://community.localwp.com/t/front-end-nodejs-status-show-output-terminal-blank-white-screen/44559/