### PR TITLE
[LOC-6734] chore: Hide headless environment details in create from backup option

### DIFF
--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -16,6 +16,9 @@ const title = `Front-end Node.js`;
 export const headlessDocsUrl = `https://wpengine.com/builders/headless`;
 export const faustJsDocsUrl = `https://github.com/wpengine/faustjs`;
 
+// When creating from a backup, we don't want to render the environment add-on UI.
+let hideHeadlessEnvironmentDetails = false;
+
 const nodeJSSiteOverviewHook = (site: Site, siteStatus: string) => {
 	const hasNodeJSHeadlessSite = site?.services?.nodejs?.role;
 	const nodeJSHeadlessLocalUrl = `localhost:${site?.services?.nodejs?.ports?.HTTP[0]}`;
@@ -58,6 +61,8 @@ export default function (context) {
 	 * Add Blueprints as an option when creating a new site
 	 */
 	hooks.addFilter('CreateSite:Steps', (steps) => {
+		hideHeadlessEnvironmentDetails = steps?.[0]?.key === 'create-from-backup';
+
 		const headlessBlueprintSteps = [
 			{
 				key: 'add-headless-blueprint-add-wordpress',
@@ -101,9 +106,12 @@ export default function (context) {
 	// Create the additional selection option to be displayed during site creation
 	hooks.addContent(
 		'NewSiteEnvironment_EnvironmentDetails',
-		({ disableButton }) => (
-			<HeadlessEnvironmentSelect disableButton={disableButton} />
-		),
+		({ disableButton }) => {
+			if (hideHeadlessEnvironmentDetails) {
+				return null;
+			}
+			return <HeadlessEnvironmentSelect disableButton={disableButton} />;
+		},
 	);
 
 	hooks.addContent('Blueprints_BlueprintsList:after', () => (


### PR DESCRIPTION
## Summary
Headless sites in Local don’t support backups, but the UI can still expose backup-related flows/content. This PR updates the Headless add-on behavior so that the **headless environment details is hidden only** in “Create site from backup” flow.

## Testing Steps
1. Enable the **Headless add-on** in Local.
2. “Create site from backup” flow.
3. Verify:
    - Headless environment details is hidden
4. “Create a new site” flow.
5. Verify:
    - Headless environment details is visible

## Screenshots / Text Samples
This the UI from the create-new-site option when creating a site:
<img width="3448" height="2152" alt="image" src="https://github.com/user-attachments/assets/b1e363a0-b0ec-4af0-a093-ba03d3f23c16" />

This the new UI from the create-from-backup option when creating a site:
<img width="3460" height="2156" alt="image" src="https://github.com/user-attachments/assets/4af97bd5-b582-4355-97e7-6c744384f4ee" />

## Reference
- [LOC-6734](https://wpengine.atlassian.net/browse/LOC-6734)

[LOC-6734]: https://wpengine.atlassian.net/browse/LOC-6734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ